### PR TITLE
Catch UnauthorizedAccessException when calling TryFindUnityAssembliesRoot.

### DIFF
--- a/UnityScript2CSharp/Program.cs
+++ b/UnityScript2CSharp/Program.cs
@@ -275,23 +275,30 @@ namespace UnityScript2CSharp
         private static bool TryFindUnityAssembliesRoot(string testPath, bool verbose, out string unityAssembliesRootPath)
         {
             if (verbose)
-                Console.WriteLine("Probbing {0}", testPath);
+                Console.WriteLine("Probing {0}", testPath);
 
-            var found = Directory.GetFiles(testPath, "*.dll").Any(file => unityProbePathRegex.IsMatch(file));
-            if (found)
+            try
             {
-                if (verbose)
-                    Console.WriteLine("Found assemblies root folder at '{0}'", testPath);
+                var found = Directory.GetFiles(testPath, "*.dll").Any(file => unityProbePathRegex.IsMatch(file));
+                if (found)
+                {
+                    if (verbose)
+                        Console.WriteLine("Found assemblies root folder at '{0}'", testPath);
 
-                unityAssembliesRootPath = testPath;
-                return true;
-            }
-
-            var folders = Directory.GetDirectories(testPath);
-            foreach (var folder in folders)
-            {
-                if (TryFindUnityAssembliesRoot(folder, verbose, out unityAssembliesRootPath))
+                    unityAssembliesRootPath = testPath;
                     return true;
+                }
+
+                var folders = Directory.GetDirectories(testPath);
+                foreach (var folder in folders)
+                {
+                    if (TryFindUnityAssembliesRoot(folder, verbose, out unityAssembliesRootPath))
+                        return true;
+                }
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                Console.WriteLine(e);
             }
 
             unityAssembliesRootPath = null;


### PR DESCRIPTION
On macOS, if the user running unityscript2csharp is not the same user that installed Unity, there may be directories inside the Unity.app that aren't accessible (this may be an issue with the Unity Editor installer). This change catches the thrown exception because the search for assemblies doesn't have to end.